### PR TITLE
VGMplay plugin: rename one variable to make it link

### DIFF
--- a/src/plugins/playback/vgm/VGMPlay/VGMPlay_AddFmts.c
+++ b/src/plugins/playback/vgm/VGMPlay/VGMPlay_AddFmts.c
@@ -117,7 +117,7 @@ extern INT32 VGMSmplPlayed;
 extern INT32 VGMSampleRate;
 extern UINT32 BlocksSent;
 extern UINT32 BlocksPlayed;
-bool VGMEnd;
+bool VGMEnd2;
 extern bool EndPlay;
 extern bool PausePlay;
 extern bool FadePlay;
@@ -586,7 +586,7 @@ void InterpretOther(UINT32 SampleCount)
 	bool NoteOn;
 	UINT8 OpMask;
 
-	if (VGMEnd)
+	if (VGMEnd2)
 		return;
 	if (PausePlay && ! ForceVGMExec)
 		return;
@@ -718,11 +718,11 @@ void InterpretOther(UINT32 SampleCount)
 							if (CMFMaxLoop && VGMCurLoop >= CMFMaxLoop)
 								FadePlay = true;
 							if (FadePlay && ! FadeTime)
-								VGMEnd = true;
+								VGMEnd2 = true;
 						}
 						else
 						{
-							VGMEnd = true;
+							VGMEnd2 = true;
 							break;
 						}
 						break;
@@ -939,7 +939,7 @@ void InterpretOther(UINT32 SampleCount)
 			if (Command < 0xF0)
 				LastCmd = Command;
 
-			if (VGMEnd)
+			if (VGMEnd2)
 				break;
 		}
 		break;
@@ -1129,9 +1129,9 @@ DRO_CommandSwitch:
 					VGMHead.lngTotalSamples = VGMSmplPos;
 					ErrorHappened = true;
 				}
-				VGMEnd = true;
+				VGMEnd2 = true;
 			}
-			if (VGMEnd)
+			if (VGMEnd2)
 				break;
 		}
 		break;


### PR DESCRIPTION
/usr/bin/ld:
/tmp/del/HippoPlayer/t2-output/linux-gcc-release-default/__vgm/VGMPlay_AddFmts-c-36def3adafcd5f78925b9bea17b84b6e.o:
 /tmp/del/HippoPlayer/src/plugins/playback/vgm/VGMPlay/VGMPlay_AddFmts.c:120: multiple definition of `VGMEnd';
/tmp/del/HippoPlayer/t2-output/linux-gcc-release-default/__vgm/VGMPlay-c-36def3adafcd5f787909263917b93301.o:
 /tmp/del/HippoPlayer/src/plugins/playback/vgm/VGMPlay/VGMPlay.c:403: first defined here